### PR TITLE
Add API responder utilities

### DIFF
--- a/backend/src/application/userService.ts
+++ b/backend/src/application/userService.ts
@@ -1,4 +1,4 @@
-export const createUserService = (deps: {}) => {
+export const createUserService = (deps: Record<string, unknown>) => {
 	// ここにUser関連のユースケース関数を追加
 	return {
 		// 例: createUser, getUser など

--- a/backend/src/utils/apiResponder.ts
+++ b/backend/src/utils/apiResponder.ts
@@ -1,0 +1,27 @@
+import { Context } from 'hono';
+import type { ApiResponse, ErrorCode } from '@prnews/common';
+import { errorStatusMap } from '@prnews/common';
+
+/** 成功レスポンス */
+export const respondSuccess = <T>(
+  c: Context,
+  data: T,
+  status: number = 200,
+  message?: string,
+) =>
+  c.json<ApiResponse<T>>({ success: true, data, message }, status);
+
+/** 失敗レスポンス（ステータス自動設定） */
+export const respondError = (
+  c: Context,
+  code: ErrorCode,
+  message?: string,
+  details?: unknown,
+  statusOverride?: number,  // 例外的に上書きしたいときだけ指定
+) => {
+  const status = statusOverride ?? errorStatusMap[code] ?? 500;
+  return c.json<ApiResponse<never>>(
+    { success: false, error: { code, details }, message },
+    status,
+  );
+};


### PR DESCRIPTION
## Summary
- add `respondSuccess` and `respondError` helpers under `backend/src/utils`
- fix banned `{}` type in `createUserService`

## Testing
- `bun run check`

------
https://chatgpt.com/codex/tasks/task_e_683f79aa6df88333aca0f0539c0e6ece